### PR TITLE
Update query.js

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -30,7 +30,11 @@ module.exports = (function() {
         err.sql = sql
         this.emit('error', err, this.callee)
       } else {
-        this.emit('success', this.formatResults(results))
+        try{
+          this.emit('success', this.formatResults(results))
+        } catch(err) {
+          this.emit('error', err);
+        }
       }
     }.bind(this)).setMaxListeners(100)
     return this


### PR DESCRIPTION
This would catch JSON.parse syntax errors and send the error through the chain instead of crashing the node process